### PR TITLE
Retrieve more terms by default.

### DIFF
--- a/grails-app/services/com/instructure/canvas/EnrollmentTermService.groovy
+++ b/grails-app/services/com/instructure/canvas/EnrollmentTermService.groovy
@@ -10,7 +10,7 @@ import java.text.SimpleDateFormat
 class EnrollmentTermService extends CanvasAPIBaseService{
 
     List<EnrollmentTerm> listEnrollmentTerms() {
-        def resp = restClient.get(canvasBaseURL + '/api/v1/accounts/1/terms'){
+        def resp = restClient.get(canvasBaseURL + '/api/v1/accounts/1/terms?per_page=50'){
             auth('Bearer ' + oauthToken)
         }
         JSONArray respArr = (JSONArray) resp.json.enrollment_terms


### PR DESCRIPTION
By default only 10 terms are returned, at the moment we locally have more than 10 active terms (they are mainly in the future) and so we weren’t getting all the terms back and hence some people looked like they didn’t have any active courses.

This isn’t an ideal fix as it should really use paging, but it pushes the limit out further and it’s much less likely for now that someone has more than 50 active terms.