### PR TITLE
Include terms that don’t have an end date.

### DIFF
--- a/grails-app/services/com/instructure/canvas/EnrollmentTermService.groovy
+++ b/grails-app/services/com/instructure/canvas/EnrollmentTermService.groovy
@@ -23,7 +23,8 @@ class EnrollmentTermService extends CanvasAPIBaseService{
         List<EnrollmentTerm> allTerms = listEnrollmentTerms()
         def utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
         allTerms.retainAll {
-            it.end_at && utcFormat.parse(it.end_at.replaceAll("Z", "+0000")).after(new Date())
+            // If there's no end date still include it (eg default term).
+            !it.end_at || utcFormat.parse(it.end_at.replaceAll("Z", "+0000")).after(new Date())
         }
         return allTerms.id
     }


### PR DESCRIPTION
In Canvas the end date is optional, an example of this is the Default Term. If you only have courses in terms without and end date you are prevented from creating new appointments because all your courses are considered to be running in terms that have finished.