### PR TITLE
Require the database URL to come from the env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Manage Appointment Groups and Time Slots in Canvas. More info [here](http://help
     dataSource:
         username: '${DB_USERNAME}'
         password: '${DB_PASSWORD}'
+        url: '${DB_URL}'
     ```
     
 3. Build & Run: `grails run-app`

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -173,4 +173,4 @@ environments:
                 dbCreate: update
                 username: '${DB_USERNAME}'
                 password: '${DB_PASSWORD}'
-                url: jdbc:mysql://localhost:3306/canvas-signup?useSSL=false
+                url: '${DB_URL}'


### PR DESCRIPTION
Rather than hardcoding the config value for the DB URL allow it to be passed in through an environmental variable.