### PR TITLE
Add created_at to the Course object.

### DIFF
--- a/src/main/groovy/com.instructure.canvas/Course.groovy
+++ b/src/main/groovy/com.instructure.canvas/Course.groovy
@@ -15,6 +15,7 @@ class Course {
     Long root_account_id
     String start_at
     String end_at
+    String created_at
     String locale
     List enrollments
     Boolean restrict_enrollments_to_course_dates


### PR DESCRIPTION
In a recent Canvas update the course object now has a created_at field and even if we don’t use it we need this in the object to allow deserialisation to occur.

Otherwise we get a stack trace along the lines of:

groovy.lang.MissingPropertyException: No such property: created_at for class: com.instructure.canvas.Course